### PR TITLE
Fixes issue #4 regarding Python 2.7/3.4 requiring ord()

### DIFF
--- a/blockchain_parser/output.py
+++ b/blockchain_parser/output.py
@@ -24,11 +24,11 @@ def is_public_key(hex_data):
         return False
 
     # Uncompressed public key
-    if len(hex_data) == 65 and hex_data[0] == 4:
+    if len(hex_data) == 65 and ord(hex_data[0]) == 4:
         return True
 
     # Compressed public key
-    if len(hex_data) == 33 and hex_data[0] in [2, 3]:
+    if len(hex_data) == 33 and ord(hex_data[0]) in [2, 3]:
         return True
 
     return False

--- a/blockchain_parser/utils.py
+++ b/blockchain_parser/utils.py
@@ -42,7 +42,7 @@ def decode_uint64(data):
 
 def decode_varint(data):
     assert(len(data) > 0)
-    size = int(data[0])
+    size = ord(data[0])
     assert(size <= 255)
 
     if size < 253:


### PR DESCRIPTION
This pull request fixes issue #4.  The affected functions are is_public_key() from output.py and decode_varint() from utils.py.
The linked issue has demos to illustrate the issue and how ord() fixes it.