### PR TITLE
Add initial support for SegWit

### DIFF
--- a/blockchain_parser/transaction.py
+++ b/blockchain_parser/transaction.py
@@ -31,6 +31,15 @@ class Transaction(object):
         self.n_outputs = 0
 
         offset = 4
+
+        # adds basic support for segwit transactions
+        #   - https://bitcoincore.org/en/segwit_wallet_dev/
+        #   - https://en.bitcoin.it/wiki/Protocol_documentation#BlockTransactions
+        self.is_segwit = False
+        if b'\x00\x01' == raw_hex[offset:offset + 2]:
+            self.is_segwit = True
+            offset += 2
+
         self.n_inputs, varint_size = decode_varint(raw_hex[offset:])
         offset += varint_size
 
@@ -48,6 +57,18 @@ class Transaction(object):
             output = Output.from_hex(raw_hex[offset:])
             offset += output.size
             self.outputs.append(output)
+
+        # currently only supports parsing of segwit transactions without error
+        # not actually saving their witnesses
+        if self.is_segwit:
+            self._offset_before_tx_witnesses = offset
+            for i in range(self.n_inputs):
+                tx_witnesses_n, varint_size = decode_varint(raw_hex[offset:])
+                offset += varint_size
+                for j in range(tx_witnesses_n):
+                    component_length, varint_size = decode_varint(raw_hex[offset:])
+                    offset += varint_size
+                    offset += component_length
 
         self.size = offset + 4
         self.hex = raw_hex[:self.size]
@@ -77,7 +98,14 @@ class Transaction(object):
     def hash(self):
         """Returns the transaction's hash"""
         if self._hash is None:
-            self._hash = format_hash(double_sha256(self.hex))
+            # segwit transactions have two transaction ids/hashes, txid and wtxid
+            # txid is a hash of all of the legacy transaction fields only
+            if self.is_segwit:
+                txid = self.hex[:4] + self.hex[6:self._offset_before_tx_witnesses] + self.hex[-4:]
+            else:
+                txid = self.hex
+            self._hash = format_hash(double_sha256(txid))
+
         return self._hash
 
     def is_coinbase(self):


### PR DESCRIPTION
This update includes initial support for parsing blogs with SegWit transactions. As of now, it is parsing SegWit transactions without saving their witnesses, but this could be easily added. I've tested it on every block starting with the blk00977.dat blockfile and it seems to be working correctly.