### PR TITLE
Fix Blockchain.get_ordered_blocks(...) bug

### DIFF
--- a/blockchain_parser/blockchain.py
+++ b/blockchain_parser/blockchain.py
@@ -96,8 +96,8 @@ class Blockchain(object):
         """
         if self.indexPath != index:
             db = plyvel.DB(index, compression=None)
-            self.blockIndexes = [DBBlockIndex(format_hash(k[1:]), bytearray(v))
-                    for k, v in db.iterator() if k[0] == 'b']
+            self.blockIndexes = [DBBlockIndex(format_hash(k[1:]), v)
+                    for k, v in db.iterator() if k[0] == ord('b')]
             db.close()
             self.blockIndexes.sort(key = lambda x: x.height)
             self.indexPath = index


### PR DESCRIPTION
Somehow, when developing the fix in https://github.com/alecalve/python-bitcoin-blockchain-parser/pull/28, my virtualenv was accidentally configured to use Python2 instead of Python3. Not realizing this, the changes in that PR were written for Python 2.7 and ~~yielded~~ did not yield ordered blocks when run with Python 3.x (surprised it worked at all w/ 2.7 actually). I've reverted to @asutoshpalai original method of parsing the leveldb key/value pairs. This should now work with Python 3.x. 