### PR TITLE
Fix bug caused by recent variable name changes

### DIFF
--- a/blockchain_parser/blockchain.py
+++ b/blockchain_parser/blockchain.py
@@ -119,5 +119,5 @@ class Blockchain(object):
             end = len(blockIndexes) - end
 
         for blkIdx in blockIndexes[start:end]:
-            blkFile = os.path.join(self.path, "blk%05d.dat" % blkIdx.nFile)
-            yield Block(get_block(blkFile, blkIdx.dataPos), blkIdx.height)
+            blkFile = os.path.join(self.path, "blk%05d.dat" % blkIdx.file)
+            yield Block(get_block(blkFile, blkIdx.data_pos), blkIdx.height)


### PR DESCRIPTION
Fix get_ordered_blocks(...) runtime error that was being caused by the recent variable name changes in https://github.com/alecalve/python-bitcoin-blockchain-parser/commit/9e5f458b7486b445a107c42c6cea2e594f7b90b8.