### PR TITLE
Add protections to not attempt to parse new blocks before they are ready

### DIFF
--- a/blockchain_parser/blockchain.py
+++ b/blockchain_parser/blockchain.py
@@ -119,6 +119,7 @@ class Blockchain(object):
             end = len(blockIndexes) - end
 
         for blkIdx in blockIndexes[start:end]:
-            if blkIdx.file != -1 and blkIdx.data_pos != -1:
-                blkFile = os.path.join(self.path, "blk%05d.dat" % blkIdx.file)
-                yield Block(get_block(blkFile, blkIdx.data_pos), blkIdx.height)
+            if blkIdx.file == -1 or blkIdx.data_pos == -1:
+                break
+            blkFile = os.path.join(self.path, "blk%05d.dat" % blkIdx.file)
+            yield Block(get_block(blkFile, blkIdx.data_pos), blkIdx.height)

--- a/blockchain_parser/blockchain.py
+++ b/blockchain_parser/blockchain.py
@@ -119,5 +119,6 @@ class Blockchain(object):
             end = len(blockIndexes) - end
 
         for blkIdx in blockIndexes[start:end]:
-            blkFile = os.path.join(self.path, "blk%05d.dat" % blkIdx.file)
-            yield Block(get_block(blkFile, blkIdx.data_pos), blkIdx.height)
+            if blkIdx.file != -1 and blkIdx.data_pos != -1:
+                blkFile = os.path.join(self.path, "blk%05d.dat" % blkIdx.file)
+                yield Block(get_block(blkFile, blkIdx.data_pos), blkIdx.height)


### PR DESCRIPTION
Parsing the very latest blocks, `get_ordered_blocks(...)` error with block indexes having values `-1` for `index.file` and `index.data_pos`. This will result in an `Error: file not found.` error. Add a check to prevent this from happening. I'm not entirely sure why this is, but it only seems to happen for the very top 1-3 blocks that were received by a live running node (perhaps because they are so new and haven't been confirmed?). These `-1` values are being set [here](https://github.com/brangerbriz/python-bitcoin-blockchain-parser/blob/master/blockchain_parser/index.py#L39-L49).