### PR TITLE
Filter out invalid orphans blocks in Blockchain.get_ordered_blocks()

### DIFF
--- a/blockchain_parser/blockchain.py
+++ b/blockchain_parser/blockchain.py
@@ -103,12 +103,89 @@ class Blockchain(object):
             self.indexPath = index
         return self.blockIndexes
 
+    def _index_confirmed(self, chain_indexes, num_confirmations=6):
+        """Check if the first block index in "chain_indexes" has at least
+        "num_confirmation" (6) blocks built on top of it.
+        If it doesn't it is not confirmed and is an orphan.
+        """
+
+        # chains holds a 2D list of sequential block hash chains
+        # as soon as there an element of length num_confirmations,
+        # we can make a decision about whether or not the block in question
+        # is confirmed by checking if it's hash is in that list
+        chains = []
+        # this is the block in question
+        first_block = None
+
+        # loop through all future blocks
+        for i, index in enumerate(chain_indexes):
+            # if this block doesn't have data don't confirm the block in question
+            if index.file == -1 or index.data_pos == -1:
+                return False
+
+            # parse the block
+            blkFile = os.path.join(self.path, "blk%05d.dat" % index.file)
+            block = Block(get_block(blkFile, index.data_pos))
+            
+            if i == 0:
+                first_block = block
+            
+            chains.append([block.hash])
+
+            for chain in chains:
+                # if this block can be appended to an existing block in one
+                # of the chains, do it
+                if chain[-1] == block.header.previous_block_hash:
+                    chain.append(block.hash)
+                
+                # if we've found a chain whose length == num_dependencies (usually 6)
+                # we are ready to make a decesion on whether or not the block in
+                # question belongs to a fork or the main chain
+                if len(chain) == num_confirmations:
+                    if first_block.hash in chain: return True
+                    else: return False
+
     def get_ordered_blocks(self, index, start=0, end=None):
         """Yields the blocks contained in the .blk files as per
         the heigt extract from the leveldb index present at path
         index maintained by bitcoind.
         """
         blockIndexes = self.__getBlockIndexes(index)
+
+        # remove small forks that may have occured while the node was running live.
+        # Occassionally a node will receive two different solutions to the next block
+        # at the same time. The Leveldb index seems to save both, not pruning the
+        # the block that leads to a shorter chain once the fork is settled without
+        # "-reindex"ing the bitcoind block data. This leads to at least two
+        # blocks with the same height in the database.
+        # We throw out blocks that don't have at least 6 other blocks on top of
+        # it (6 confirmations).
+        orphans = [] # hold blocks that are orphans/forks with < 6 blocks built on top
+        last_height = -1
+        for i, blockIdx in enumerate(blockIndexes):
+            if last_height > -1:
+                # if this block is the same height as the last block an orphan has
+                # occurred, now we have to figure out which of the two to keep
+                if blockIdx.height == last_height:
+
+                    # loop through future blocks until we find a chain of at least
+                    # six blocks that includes this block. If we can't find one
+                    # remove this block as it is invalid
+                    if self._index_confirmed(blockIndexes[i:]):
+
+                        # if this block is confirmed, the unconfirmed block is
+                        # the previous one. Remove it.
+                        orphans.append(blockIndexes[i - 1].hash)
+                    else:
+
+                        # if this block isn't confirmed, remove it.
+                        orphans.append(blockIndexes[i].hash)
+
+            last_height = blockIdx.height
+
+        # filter out the orphan blocks, so we are left only with block indexes
+        # that have been confirmed (or are new enough that they haven't yet been confirmed)
+        blockIndexes = list(filter(lambda block: block.hash not in orphans, blockIndexes))
 
         if end is None:
             end = len(blockIndexes)


### PR DESCRIPTION
Bitcoin Core saves all blocks it receives in it's LevelDB index and `.dat` independent of whether or not they have enough confirmations to be considered the main chain. If you leave a node running for a while, it will accumulate orphan blocks if two miners find simultaneous solutions to the top of the chain (or if the network is under attack). These orphan blocks are not removed from the LevelDB index automatically and therefore `Blockchain.get_ordered_blocks()` may return multiple blocks for the same block height. Only one of these blocks is valid, so I've added a check to filter out blocks that have less than 6 confirmed blocks extending the chain on top of them. 