### PR TITLE
Improve a blocks transaction parsing speed by progressively growing slice width of transaction hex

### DIFF
--- a/blockchain_parser/block.py
+++ b/blockchain_parser/block.py
@@ -26,8 +26,15 @@ def get_block_transactions(raw_hex):
     n_transactions, offset = decode_varint(transaction_data)
 
     for i in range(n_transactions):
-        transaction = Transaction.from_hex(transaction_data[offset:])
-        yield transaction
+        # Try from 1024 (1KiB) -> 1073741824 (1GiB) slice widths
+        for j in range(0, 20):
+            try:
+                offset_e = offset + (1024 * 2 ** j)
+                transaction = Transaction.from_hex(transaction_data[offset:offset_e])
+                yield transaction
+                break
+            except:
+                continue
 
         # Skipping to the next transaction
         offset += transaction.size


### PR DESCRIPTION
I noticed while using this to parse through transactions on a 32mb block- it was very very slow, and further investigation showed that even 1mb blocks were slower than smaller blocks. The culprit is an unbounded slice. This PR progressively tries larger slices until it finds one that works; the default works for almost all transactions. This reduced the time for a 32mb block parse from over an hour to just over a minute, and improves 1mb blocks on my machine by about 50%. 

It works its way up to 1GiB so that this library will work well into the future. 