### PR TITLE
Optimize is_coinbase() implementation

### DIFF
--- a/blockchain_parser/transaction.py
+++ b/blockchain_parser/transaction.py
@@ -135,7 +135,7 @@ class Transaction(object):
 
     def is_coinbase(self):
         """Returns whether the transaction is a coinbase transaction"""
-        return len(self.inputs) == 1 and self.inputs[0].transaction_hash == "0" * 64:
+        return len(self.inputs) == 1 and self.inputs[0].transaction_hash == "0" * 64
 
     def uses_replace_by_fee(self):
         """Returns whether the transaction opted-in for RBF"""

--- a/blockchain_parser/transaction.py
+++ b/blockchain_parser/transaction.py
@@ -135,10 +135,7 @@ class Transaction(object):
 
     def is_coinbase(self):
         """Returns whether the transaction is a coinbase transaction"""
-        for input in self.inputs:
-            if input.transaction_hash == "0" * 64:
-                return True
-        return False
+        return len(self.inputs) == 1 and self.inputs[0].transaction_hash == "0" * 64:
 
     def uses_replace_by_fee(self):
         """Returns whether the transaction opted-in for RBF"""

--- a/blockchain_parser/transaction.py
+++ b/blockchain_parser/transaction.py
@@ -135,7 +135,8 @@ class Transaction(object):
 
     def is_coinbase(self):
         """Returns whether the transaction is a coinbase transaction"""
-        return len(self.inputs) == 1 and self.inputs[0].transaction_hash == "0" * 64
+        return len(self.inputs) == 1 and \ 
+               self.inputs[0].transaction_hash == "0" * 64
 
     def uses_replace_by_fee(self):
         """Returns whether the transaction opted-in for RBF"""


### PR DESCRIPTION
As Bitcoin consensus rule, coinbase tx must the first tx in block.
The Bitcoin Core's implement is here:
https://github.com/bitcoin/bitcoin/blob/fa11c036e97f18d31cffaf7430fbe84fe44efbcc/src/validation.cpp#L3104

Bitcoin Core's IsCoinBase() implement is here:
https://github.com/bitcoin/bitcoin/blob/f0c9e1c22b8a043983f3ba90ad910b67cf981e36/src/primitives/transaction.h#L333

I imitated this implementation, and don't need a loop now.