### PR TITLE
Using bytes.hex instead of binascii.hexlify

### DIFF
--- a/blockchain_parser/utils.py
+++ b/blockchain_parser/utils.py
@@ -9,7 +9,6 @@
 # modified, propagated, or distributed except according to the terms contained
 # in the LICENSE file.
 
-from binascii import hexlify
 import hashlib
 import struct
 

--- a/blockchain_parser/utils.py
+++ b/blockchain_parser/utils.py
@@ -26,7 +26,7 @@ def double_sha256(data):
 
 
 def format_hash(hash_):
-    return str(hexlify(hash_[::-1]).decode("utf-8"))
+    return hash_[::-1].hex()
 
 
 def decode_uint32(data):


### PR DESCRIPTION
To convert from bytes to an hex string the `bytes.hex` method is much faster than  `str(hexlify(…).decode('uft-8'))`.

Consider this rough test:

    $ python3 -m timeit "b'\x00\x00\x00\x00\x00\x19\xd6h\x9c\x08Z\xe1e\x83\x1e\x93O\xf7c\xaeF\xa2\xa6\xc1r\xb3\xf1\xb6\n\x8c\xe2o'.hex()"
    5000000 loops, best of 5: 72.3 nsec per loop
    $ python3 -m timeit -s "from binascii import hexlify" "hexlify(b'\x00\x00\x00\x00\x00\x19\xd6h\x9c\x08Z\xe1e\x83\x1e\x93O\xf7c\xaeF\xa2\xa6\xc1r\xb3\xf1\xb6\n\x8c\xe2o').decode('utf-8')"
    2000000 loops, best of 5: 137 nsec per loop
    $ python3 -m timeit -s "from binascii import hexlify" "str(hexlify(b'\x00\x00\x00\x00\x00\x19\xd6h\x9c\x08Z\xe1e\x83\x1e\x93O\xf7c\xaeF\xa2\xa6\xc1r\xb3\xf1\xb6\n\x8c\xe2o').decode('utf-8'))"
    2000000 loops, best of 5: 194 nsec per loop
    
The [documentation](https://docs.python.org/3/library/binascii.html#binascii.hexlify) also reports that `bytes.hex` is a convenient way of doing what you need.