### PR TITLE
fixed the ordering for get_ordered_blocks by adding sorting to indexes

### DIFF
--- a/blockchain_parser/blockchain.py
+++ b/blockchain_parser/blockchain.py
@@ -206,7 +206,7 @@ class Blockchain(object):
         # that have been confirmed
         # (or are new enough that they haven't yet been confirmed)
         blockIndexes = list(filter(lambda block: block.hash not in stale_blocks, blockIndexes))
-
+        blockIndexes.sort(key= lambda b: b.height)
         if end is None:
             end = len(blockIndexes)
 


### PR DESCRIPTION
The ordering became random due to the new way leveldb indexes are being accessed. Sorting resolves this problem.